### PR TITLE
Fixed path for 'related' request

### DIFF
--- a/src/endpoints/animes.ts
+++ b/src/endpoints/animes.ts
@@ -89,7 +89,7 @@ export const animes = ({ get }: RequestMethods) => {
    * @param params
    */
   const related = ({ id }: Id<AnimeId>): Promise<AnimeRelation[]> => (
-    get(`/animes/${id}/relation`, {})
+    get(`/animes/${id}/related`, {})
   );
 
   /**


### PR DESCRIPTION
`related` doesn't work anymore. The path has been changed.