### PR TITLE
Non get params moved to body from query

### DIFF
--- a/src/apiProvider.ts
+++ b/src/apiProvider.ts
@@ -60,13 +60,13 @@ export const apiProvider = ({
   let accessToken: Token = token;
 
   const apiRequest: RequestHandler = async (type, endpoint, params): Promise<any> => {
-    const inBodyParams = type !==  "GET"; // || type !== "HEAD"
+    const shouldUseBodyParams = type !== 'GET';
 
     let fullPath = `/api${endpoint}`;
 
-    if(!inBodyParams) {
+    if (!shouldUseBodyParams) {
       const searchParams = new URLSearchParams(Object.entries(params));
-      fullPath += "?" + searchParams
+      fullPath += `?${searchParams}`;
     }
 
     const headers = new Headers({
@@ -77,14 +77,14 @@ export const apiProvider = ({
       headers.set('Authorization', `Bearer ${accessToken}`);
     }
 
-    if(inBodyParams && params) {
-      headers.set('Content-Type', `application/json`);
+    if (shouldUseBodyParams && params) {
+      headers.set('Content-Type', 'application/json');
     }
 
     return request(fullPath, {
       method: type,
       headers: headers,
-      body: inBodyParams && params ? JSON.stringify(params) : undefined
+      body: shouldUseBodyParams && params ? JSON.stringify(params) : undefined,
     });
   };
 

--- a/src/apiProvider.ts
+++ b/src/apiProvider.ts
@@ -60,8 +60,14 @@ export const apiProvider = ({
   let accessToken: Token = token;
 
   const apiRequest: RequestHandler = async (type, endpoint, params): Promise<any> => {
-    const searchParams = new URLSearchParams(Object.entries(params));
-    const fullPath = `/api${endpoint}?${searchParams.toString()}`;
+    const inBodyParams = type !==  "GET"; // || type !== "HEAD"
+
+    let fullPath = `/api${endpoint}`;
+
+    if(!inBodyParams) {
+      const searchParams = new URLSearchParams(Object.entries(params));
+      fullPath += "?" + searchParams
+    }
 
     const headers = new Headers({
       'User-Agent': clientName,
@@ -71,9 +77,14 @@ export const apiProvider = ({
       headers.set('Authorization', `Bearer ${accessToken}`);
     }
 
+    if(inBodyParams && params) {
+      headers.set('Content-Type', `application/json`);
+    }
+
     return request(fullPath, {
       method: type,
       headers: headers,
+      body: inBodyParams && params ? JSON.stringify(params) : undefined
     });
   };
 


### PR DESCRIPTION
Теперь все не GET запросы параметры передают в теле, а не в query строке. Должно исправить https://github.com/Capster/node-shikimori/issues/15